### PR TITLE
ifconfig: replace list_interfaces_of_type by Interface.listing

### DIFF
--- a/scripts/cli/base_interfaces_test.py
+++ b/scripts/cli/base_interfaces_test.py
@@ -18,7 +18,7 @@ import unittest
 from vyos.configsession import ConfigSession
 from netifaces import ifaddresses, AF_INET, AF_INET6
 from vyos.validate import is_intf_addr_assigned, is_ipv6_link_local
-from vyos.interfaces import list_interfaces_of_type
+from vyos.ifconfig import Interface
 
 class BasicInterfaceTest:
     class BaseTest(unittest.TestCase):

--- a/scripts/cli/test_interfaces_bonding.py
+++ b/scripts/cli/test_interfaces_bonding.py
@@ -18,7 +18,7 @@ import unittest
 
 from base_interfaces_test import BasicInterfaceTest
 
-from vyos.interfaces import list_interfaces_of_type
+from vyos.ifconfig import Interface
 from vyos.configsession import ConfigSessionError
 
 class BondingInterfaceTest(BasicInterfaceTest.BaseTest):
@@ -33,7 +33,7 @@ class BondingInterfaceTest(BasicInterfaceTest.BaseTest):
         members = []
         # we need to filter out VLAN interfaces identified by a dot (.)
         # in their name - just in case!
-        for tmp in list_interfaces_of_type("ethernet"):
+        for tmp in Interface.listing("ethernet"):
             if not '.' in tmp:
                 members.append(tmp)
 

--- a/scripts/cli/test_interfaces_bridge.py
+++ b/scripts/cli/test_interfaces_bridge.py
@@ -17,7 +17,7 @@
 import unittest
 
 from base_interfaces_test import BasicInterfaceTest
-from vyos.interfaces import list_interfaces_of_type
+from vyos.ifconfig import Interface
 
 class BridgeInterfaceTest(BasicInterfaceTest.BaseTest):
     def setUp(self):
@@ -30,7 +30,7 @@ class BridgeInterfaceTest(BasicInterfaceTest.BaseTest):
         members = []
         # we need to filter out VLAN interfaces identified by a dot (.)
         # in their name - just in case!
-        for tmp in list_interfaces_of_type("ethernet"):
+        for tmp in Interface.listing("ethernet"):
             if not '.' in tmp:
                 members.append(tmp)
 

--- a/scripts/cli/test_interfaces_ethernet.py
+++ b/scripts/cli/test_interfaces_ethernet.py
@@ -17,7 +17,7 @@
 import unittest
 
 from base_interfaces_test import BasicInterfaceTest
-from vyos.interfaces import list_interfaces_of_type
+from vyos.ifconfig import Interface
 
 class EthernetInterfaceTest(BasicInterfaceTest.BaseTest):
     def setUp(self):
@@ -29,7 +29,7 @@ class EthernetInterfaceTest(BasicInterfaceTest.BaseTest):
 
         # we need to filter out VLAN interfaces identified by a dot (.)
         # in their name - just in case!
-        for tmp in list_interfaces_of_type("ethernet"):
+        for tmp in Interface.listing("ethernet"):
             if not '.' in tmp:
                 self._interfaces.append(tmp)
 


### PR DESCRIPTION
the last T2057 patch removed list_interfaces_of_type and replaced it by a classmethod of Interface (via Register) called listing. This patch update the function calls.